### PR TITLE
fix build and bring plugin to current travis standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ language: ruby
 cache: bundler
 before_install:
 - sudo apt-get install libzmq3-dev
-rvm:
-- jruby-1.7.24
-script:
-- bundle exec rspec spec
-jdk: oraclejdk8
 matrix:
   include:
   - rvm: jruby-9.1.13.0
@@ -20,3 +15,7 @@ matrix:
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in logstash-mass_effect.gemspec
 gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+
+echo "Starting build process in: `pwd`"
+source ./ci/setup.sh
+
+if [[ -f "ci/run.sh" ]]; then
+    echo "Running custom build script in: `pwd`/ci/run.sh"
+    source ./ci/run.sh
+else
+    echo "Running default build scripts in: `pwd`/ci/build.sh"
+    bundle install
+    bundle exec rake vendor
+    bundle exec rspec spec
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+if [ "$LOGSTASH_BRANCH" ]; then
+    echo "Building plugin using Logstash source"
+    BASE_DIR=`pwd`
+    echo "Checking out branch: $LOGSTASH_BRANCH"
+    git clone -b $LOGSTASH_BRANCH https://github.com/elastic/logstash.git ../../logstash --depth 1
+    printf "Checked out Logstash revision: %s\n" "$(git -C ../../logstash rev-parse HEAD)"
+    cd ../../logstash
+    echo "Building plugins with Logstash version:"
+    cat versions.yml
+    echo "---"
+    # We need to build the jars for that specific version
+    echo "Running gradle assemble in: `pwd`"
+    ./gradlew assemble
+    cd $BASE_DIR
+    export LOGSTASH_SOURCE=1
+else
+    echo "Building plugin using released gems on rubygems"
+fi

--- a/spec/plugin_mixins/zeromq_spec.rb
+++ b/spec/plugin_mixins/zeromq_spec.rb
@@ -5,6 +5,10 @@ require 'logstash/plugin_mixins/zeromq'
 class Dummy < LogStash::Inputs::Base
   attr_accessor :mode
 
+  def set_logger(logger)
+   @logger = logger
+  end
+
   include LogStash::PluginMixins::ZeroMQ
   def server?
     @mode == "server"
@@ -44,7 +48,7 @@ describe LogStash::PluginMixins::ZeroMQ do
 
       it "a 'bound' info line is logged" do
         allow(tracer).to receive(:debug)
-        impl.logger = tracer
+        impl.set_logger(tracer)  
         expect(tracer).to receive(:info).with("0mq: bound", {:address=>"tcp://127.0.0.1:#{port}"})
         impl.setup(socket, "tcp://127.0.0.1:#{port}")
       end
@@ -59,7 +63,7 @@ describe LogStash::PluginMixins::ZeroMQ do
 
       it "a 'connected' info line is logged" do
         allow(tracer).to receive(:debug)
-        impl_client.logger = tracer
+        impl_client.set_logger(tracer) 
         expect(tracer).to receive(:info).with("0mq: connected", {:address=>"tcp://127.0.0.1:#{port}"})
         impl_client.setup(socket, "tcp://127.0.0.1:#{port}")
       end


### PR DESCRIPTION
Honestly not sure why the logger changes are needed, it seems like the old code should have worked (and it did for a long time), but running without this 'fix' fails with the following error.

```
     Failure/Error: impl.logger = tracer
     
     NoMethodError:
       undefined method `logger=' for #<Dummy:0x270d5060>
       Did you mean?  logger
```
The other changes are copy paste from other more updated projects. 